### PR TITLE
Allow harvey to work with the Paul Irish matchmedia polyfill 

### DIFF
--- a/harvey.coffee
+++ b/harvey.coffee
@@ -104,7 +104,7 @@ class this.Harvey
   @_window_matchmedia: (mediaQuery) ->
 
     # always try to use the native matchMedia interface where available!
-    if window.matchMedia
+    if window.matchMedia and 'addListener' in window.matchMedia('')
       @_mediaList[mediaQuery] = window.matchMedia(mediaQuery) if mediaQuery not of @_mediaList
       return @_mediaList[mediaQuery]
 

--- a/harvey.js
+++ b/harvey.js
@@ -133,7 +133,7 @@
 
 
     Harvey._window_matchmedia = function(mediaQuery) {
-      if (window.matchMedia) {
+      if (window.matchMedia && 'addListener' in window.matchMedia('')) {
         if (!(mediaQuery in this._mediaList)) {
           this._mediaList[mediaQuery] = window.matchMedia(mediaQuery);
         }


### PR DESCRIPTION
Harvey's matchMedia polyfill breaks when another polyfill is present that doesn't implement support for the addListener function. This tiny change would fix issue #8. 
