### PR TITLE
Add support for the Paul Irish matchMedia polyfill with IE10 update

### DIFF
--- a/harvey.coffee
+++ b/harvey.coffee
@@ -104,7 +104,7 @@ class this.Harvey
   @_window_matchmedia: (mediaQuery) ->
 
     # always try to use the native matchMedia interface where available!
-    if window.matchMedia
+    if window.matchMedia and 'addListener' in window.matchMedia('all')
       @_mediaList[mediaQuery] = window.matchMedia(mediaQuery) if mediaQuery not of @_mediaList
       return @_mediaList[mediaQuery]
 

--- a/harvey.js
+++ b/harvey.js
@@ -133,7 +133,7 @@
 
 
     Harvey._window_matchmedia = function(mediaQuery) {
-      if (window.matchMedia) {
+      if (window.matchMedia && 'addListener' in window.matchMedia('all')) {
         if (!(mediaQuery in this._mediaList)) {
           this._mediaList[mediaQuery] = window.matchMedia(mediaQuery);
         }


### PR DESCRIPTION
Combining adammiller's pull request - https://github.com/harvesthq/harvey/pull/11 and a fix on Paul Irish's matchMedia.js project - https://github.com/paulirish/matchMedia.js/pull/33 .  Prevents Invalid Argument error in IE10 by adding the 'all' argument to window.matchMedia
