### PR TITLE
updated CDN include to https

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@
 
   <p class="dimensions"></p>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 
   <script src="../harvey.js" type="text/javascript"></script>
   <script src="interface.js" type="text/javascript"></script>


### PR DESCRIPTION
to fix the following 
```
Mixed Content: The page at 'https://harvesthq.github.io/harvey/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
demo.js:1 Uncaught ReferenceError: $ is not defined
    at demo.js:1
```